### PR TITLE
feat: Turn on UseCharacterInfo flag

### DIFF
--- a/Characters/Husk_player/Husk_player.xml
+++ b/Characters/Husk_player/Husk_player.xml
@@ -9,6 +9,7 @@
     Group="human"
     Humanoid="True"
     HasInfo="True"
+    HasCharacterInfo="True"
     CanInteract="True"
     CanClimb="true"
     Husk="False"

--- a/Characters/Husk_player_chimera/Husk_player_chimera.xml
+++ b/Characters/Husk_player_chimera/Husk_player_chimera.xml
@@ -7,6 +7,7 @@
   Group="human"
   Humanoid="False"
   HasInfo="True"
+  HasCharacterInfo="True"
   CanInteract="True"
   CanClimb="True"
   Husk="False"

--- a/Characters/Husk_player_exosuit/Husk_player_exosuit.xml
+++ b/Characters/Husk_player_exosuit/Husk_player_exosuit.xml
@@ -9,6 +9,7 @@
     Group="human"
     Humanoid="True"
     HasInfo="True"
+    HasCharacterInfo="True"
     CanInteract="True"
     CanClimb="true"
     Husk="False"

--- a/Characters/Husk_player_prowler/Husk_player_prowler.xml
+++ b/Characters/Husk_player_prowler/Husk_player_prowler.xml
@@ -8,6 +8,7 @@
     Group="human"
     Humanoid="False"
     HasInfo="True"
+    HasCharacterInfo="True"
     CanInteract="True"
     CanClimb="True"
     Husk="False"


### PR DESCRIPTION
Turn on UseCharacterInfo flag which is used to mark this character as a "campaign character" according to barotrauma docs.