### PR TITLE
fix: add a prefix to symbiosis talent as it conflicts with many other mods

### DIFF
--- a/Job/TalentTrees.xml
+++ b/Job/TalentTrees.xml
@@ -11,7 +11,7 @@
       </TalentOptions>
 
       <TalentOptions requiredtalents="2" maxchosentalents="7">
-        <TalentOption identifier="symbiosis" />
+        <TalentOption identifier="hh_symbiosis" />
         <TalentOption identifier="overcooked" />
         <TalentOption identifier="refeeding" />
         <TalentOption identifier="rupturedskin" />

--- a/Job/Talents.xml
+++ b/Job/Talents.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Talents>
-  <Talent identifier="symbiosis">
-    <Description tag="talentdescription.symbiosis">
+  <Talent identifier="hh_symbiosis">
+    <Description tag="talentdescription.hh_symbiosis">
       <Replace tag="[stun]" value="15" color="gui.green"/>
       <Replace tag="[damage]" value="15" color="gui.green"/>
       <Replace tag="[healing]" value="50" color="gui.green"/>

--- a/Language/BrazilianPortuguese/BrazilianPortuguese.xml
+++ b/Language/BrazilianPortuguese/BrazilianPortuguese.xml
@@ -2,8 +2,8 @@
 <infotexts language="Brazilian Portuguese" nowhitespace="false" translatedname="Brazilian Portuguese">
   <jobName.PlayerHuskJob>Husk</jobName.PlayerHuskJob>
   <jobdescription.PlayerHuskJob>Um cadáver em decomposição enfiado em um antigo traje de mergulho, ele flutuou pela eclusa e nunca se incomodou em sair. Ninguém sabe o que ele quer—se é que quer alguma coisa. Ele paira nos corredores, ocasionalmente se contorcendo, ocasionalmente babando um fluido escuro e viscoso que cheira levemente a salmoura. Alguns dizem que ele clica suavemente à noite, um som oco que faz os compartimentos tremerem. O que ele foi um dia, agora é outra coisa, e decidiu ficar.</jobdescription.PlayerHuskJob>
-  <talentname.symbiosis>Simbiose</talentname.symbiosis>
-  <talentdescription.symbiosis>Enquanto estiver perto de amigos, eles ganham [stun]% de resistência a atordoamento e resistência a dano. Sempre que você cura um aliado, você também se cura em [healing]% desse valor.</talentdescription.symbiosis>
+  <talentname.hh_symbiosis>Simbiose</talentname.hh_symbiosis>
+  <talentdescription.hh_symbiosis>Enquanto estiver perto de amigos, eles ganham [stun]% de resistência a atordoamento e resistência a dano. Sempre que você cura um aliado, você também se cura em [healing]% desse valor.</talentdescription.hh_symbiosis>
   <talentname.feelsweirdman>Secreção maravilhosa</talentname.feelsweirdman>
   <talentdescription.feelsweirdman>Enquanto estiver perto de amigos, eles ganham [bleedResistance]% de resistência a sangramento e reduzem a duração da ferida por sangramento em [bleedWound]% .</talentdescription.feelsweirdman>
   <talentname.bestfriends>Melhores amigos para sempre</talentname.bestfriends>

--- a/Language/CastilianSpanish/CastilianSpanish.xml
+++ b/Language/CastilianSpanish/CastilianSpanish.xml
@@ -2,8 +2,8 @@
 <infotexts language="Castilian Spanish" nowhitespace="false" translatedname="Castilian Spanish">
   <jobName.PlayerHuskJob>Cáscara</jobName.PlayerHuskJob>
   <jobdescription.PlayerHuskJob>Un cadáver en descomposición metido en un antiguo traje de buzo, flotó a través de la esclusa y nunca se molestó en irse. Nadie sabe lo que quiere, si es que quiere algo en absoluto. Se queda en los pasillos, a veces sacudiéndose, a veces goteando un fluido oscuro y viscoso que huele levemente a salmuera. Algunos dicen que hace clic suavemente por la noche, un sonido hueco que hace vibrar las estructuras. Lo que una vez fue, ahora es otra cosa, y ha decidido quedarse.</jobdescription.PlayerHuskJob>
-  <talentname.symbiosis>Simbiopatía</talentname.symbiosis>
-  <talentdescription.symbiosis>Mientras estén cerca de amigos, obtienen un [stun]% de resistencia a aturdimientos y resistencia al daño. Siempre que sanes a un aliado, también te sanas a ti mismo por [healing]% de esa cantidad.</talentdescription.symbiosis>
+  <talentname.hh_symbiosis>Simbiopatía</talentname.hh_symbiosis>
+  <talentdescription.hh_symbiosis>Mientras estén cerca de amigos, obtienen un [stun]% de resistencia a aturdimientos y resistencia al daño. Siempre que sanes a un aliado, también te sanas a ti mismo por [healing]% de esa cantidad.</talentdescription.hh_symbiosis>
   <talentname.feelsweirdman>Secreción maravillosa</talentname.feelsweirdman>
   <talentdescription.feelsweirdman>Mientras estén cerca de amigos, obtienen un [bleedResistance]% de resistencia a sangrado y reducen la duración de las heridas por sangrado en [bleedWound]% .</talentdescription.feelsweirdman>
   <talentname.bestfriends>Mejores amigos para siempre</talentname.bestfriends>

--- a/Language/English/English.xml
+++ b/Language/English/English.xml
@@ -2,8 +2,8 @@
 <infotexts language="English" nowhitespace="false" translatedname="English">
   <jobName.PlayerHuskJob>Husk</jobName.PlayerHuskJob>
   <jobdescription.PlayerHuskJob>A rotting corpse stuffed into an ancient diver's suit, it drifted in through the airlock and never bothered to leave. No one knows what it wants—if it even wants anything at all. It lingers in the corridors, occasionally twitching, occasionally drooling a dark, viscous fluid that smells faintly of brine. Some say it clicks softly at night, a hollow sound that rattles the bulkheads. Whatever it once was, now it’s something else, and it’s decided to stay.</jobdescription.PlayerHuskJob>
-  <talentname.symbiosis>Symbiosis</talentname.symbiosis>
-  <talentdescription.symbiosis>While near friends, they gain [stun]% stun resistance and damage resistance. Whenever you heal an ally, you also heal yourself for [healing]% of that amount.</talentdescription.symbiosis>
+  <talentname.hh_symbiosis>Symbiosis</talentname.hh_symbiosis>
+  <talentdescription.hh_symbiosis>While near friends, they gain [stun]% stun resistance and damage resistance. Whenever you heal an ally, you also heal yourself for [healing]% of that amount.</talentdescription.hh_symbiosis>
   <talentname.feelsweirdman>Wounderful secretion</talentname.feelsweirdman>
   <talentdescription.feelsweirdman>While near friends, they gain [bleedResistance]% bleed resistance and reduce bleeding wound duration by [bleedWound]%.</talentdescription.feelsweirdman>
   <talentname.bestfriends>Best friends forever</talentname.bestfriends>

--- a/Language/French/French.xml
+++ b/Language/French/French.xml
@@ -2,8 +2,8 @@
 <infotexts language="French" nowhitespace="false" translatedname="French">
   <jobName.PlayerHuskJob>Husk</jobName.PlayerHuskJob>
   <jobdescription.PlayerHuskJob>Un cadavre en décomposition coincé dans un ancien costume de plongeur, il a dérivé dans l'airlock et n'a jamais daigné partir. Personne ne sait ce qu'il veut - s'il veut même quelque chose. Il erre dans les couloirs, parfois en convulsant, parfois bavant un fluide sombre et visqueux qui sent légèrement la saumure. Certains disent qu'il cliquette doucement la nuit, un son creux qui rattache les cloisons. Quoi qu'il était autrefois, maintenant c'est autre chose, et il a décidé de rester.</jobdescription.PlayerHuskJob>
-  <talentname.symbiosis>Symbiose</talentname.symbiosis>
-  <talentdescription.symbiosis>Lorsqu'il est près d'amis, il gagne [stun]% de résistance aux étourdissements et à la résistance aux dégâts. Chaque fois que vous guérissez un allié, vous vous guérissez également de [healing]% de ce montant.</talentdescription.symbiosis>
+  <talentname.hh_symbiosis>Symbiose</talentname.hh_symbiosis>
+  <talentdescription.hh_symbiosis>Lorsqu'il est près d'amis, il gagne [stun]% de résistance aux étourdissements et à la résistance aux dégâts. Chaque fois que vous guérissez un allié, vous vous guérissez également de [healing]% de ce montant.</talentdescription.hh_symbiosis>
   <talentname.feelsweirdman>Sécrétion merveilleuse</talentname.feelsweirdman>
   <talentdescription.feelsweirdman>Lorsqu'il est près d'amis, il gagne [bleedResistance]% de résistance aux saignements et réduit la durée des blessures saignantes de [bleedWound]%.</talentdescription.feelsweirdman>
   <talentname.bestfriends>Meilleurs amis pour toujours</talentname.bestfriends>

--- a/Language/German/German.xml
+++ b/Language/German/German.xml
@@ -2,8 +2,8 @@
 <infotexts language="German" nowhitespace="false" translatedname="German">
   <jobName.PlayerHuskJob>Husk</jobName.PlayerHuskJob>
   <jobdescription.PlayerHuskJob>Ein verrottender Leichnam, der in einen alten Taucheranzug gestopft ist, schwebte durch die Luftschleuse und ließ sich nie wieder blicken. Niemand weiß, was es will – falls es überhaupt etwas will. Es verweilt in den Gängen, zuckt gelegentlich, sabbert hin und wieder eine dunkle, zähflüssige Flüssigkeit, die schwach nach Salzwasser riecht. Einige sagen, es klickt nachts leise, ein hohler Klang, der die Bulkheads erschüttert. Was es einmal war, ist jetzt etwas anderes, und es hat beschlossen zu bleiben.</jobdescription.PlayerHuskJob>
-  <talentname.symbiosis>Symbiose</talentname.symbiosis>
-  <talentdescription.symbiosis>In der Nähe von Freunden erhalten sie [stun]% Stun-Resistenz und Schadenresistenz. Immer wenn du einen Verbündeten heilst, heilst du auch dich selbst für [healing]% dieses Betrags.</talentdescription.symbiosis>
+  <talentname.hh_symbiosis>Symbiose</talentname.hh_symbiosis>
+  <talentdescription.hh_symbiosis>In der Nähe von Freunden erhalten sie [stun]% Stun-Resistenz und Schadenresistenz. Immer wenn du einen Verbündeten heilst, heilst du auch dich selbst für [healing]% dieses Betrags.</talentdescription.hh_symbiosis>
   <talentname.feelsweirdman>Wunderbare Sekretion</talentname.feelsweirdman>
   <talentdescription.feelsweirdman>In der Nähe von Freunden erhalten sie [bleedResistance]% Blutungsresistenz und reduzieren die Dauer von Blutungswunden um [bleedWound]%.</talentdescription.feelsweirdman>
   <talentname.bestfriends>Beste Freunde für immer</talentname.bestfriends>

--- a/Language/Japanese/Japanese.xml
+++ b/Language/Japanese/Japanese.xml
@@ -2,8 +2,8 @@
 <infotexts language="Japanese" nowhitespace="false" translatedname="Japanese">
   <jobName.PlayerHuskJob>ハスク</jobName.PlayerHuskJob>
   <jobdescription.PlayerHuskJob>腐った死体が古代のダイバーのスーツに詰め込まれ、エアロックを通り抜けて漂ってきたが、出て行くことを気にしなかった。 それが何を望んでいるのか、あるいは何も望んでいないのか、誰にもわからない。廊下に留まり、時折痙攣し、時折暗い粘性の液体を垂らす。それはわずかに塩水の匂いがする。誰かは、夜に静かにカチカチと音を立てると言う。それは空洞の音で、壁を揺らす。元々何であったのかは分からないが、今は何か別のものであり、留まることを決めた。</jobdescription.PlayerHuskJob>
-  <talentname.symbiosis>共生</talentname.symbiosis>
-  <talentdescription.symbiosis>友達の近くにいる間、[stun]%のスタン耐性とダメージ耐性を得る。味方を癒すたびに、自分自身もその量の[healing]%を癒す。</talentdescription.symbiosis>
+  <talentname.hh_symbiosis>共生</talentname.hh_symbiosis>
+  <talentdescription.hh_symbiosis>友達の近くにいる間、[stun]%のスタン耐性とダメージ耐性を得る。味方を癒すたびに、自分自身もその量の[healing]%を癒す。</talentdescription.hh_symbiosis>
   <talentname.feelsweirdman>素晴らしい分泌物</talentname.feelsweirdman>
   <talentdescription.feelsweirdman>友達の近くにいる間、[bleedResistance]%の出血耐性を得て、出血の持続時間を[bleedWound]%減少させる。</talentdescription.feelsweirdman>
   <talentname.bestfriends>永遠の親友</talentname.bestfriends>

--- a/Language/Korean/Korean.xml
+++ b/Language/Korean/Korean.xml
@@ -2,8 +2,8 @@
 <infotexts language="Korean" nowhitespace="false" translatedname="Korean">
   <jobName.PlayerHuskJob>허스크</jobName.PlayerHuskJob>
   <jobdescription.PlayerHuskJob>썩어가는 시체가 고대 잠수복에 채워져 공기 잠금 장치를 통해 흘러들어왔고, 결코 나가려고 하지 않았다. 그것이 무엇을 원하는지—심지어 원하는 것이 있는지도 아무도 모른다. 그것은 복도에서 머물며 가끔은 경련을 일으키고, 가끔은 짭짤한 냄새가 나는 끈적한 액체를 흘린다. 어떤 이들은 그것이 밤에 부드럽게 클릭 소리를 낸다고 말한다. 그것은 무엇이었든, 이제는 다른 것이 되었고, 머물기로 결정했다.</jobdescription.PlayerHuskJob>
-  <talentname.symbiosis>공생</talentname.symbiosis>
-  <talentdescription.symbiosis>친구 근처에 있을 때, 그들은 [stun]% 스턴 저항력과 피해 저항력을 얻습니다. 동료를 치료할 때마다, 자신도 그 양의 [healing]%만큼 치료됩니다.</talentdescription.symbiosis>
+  <talentname.hh_symbiosis>공생</talentname.hh_symbiosis>
+  <talentdescription.hh_symbiosis>친구 근처에 있을 때, 그들은 [stun]% 스턴 저항력과 피해 저항력을 얻습니다. 동료를 치료할 때마다, 자신도 그 양의 [healing]%만큼 치료됩니다.</talentdescription.hh_symbiosis>
   <talentname.feelsweirdman>기묘한 분비물</talentname.feelsweirdman>
   <talentdescription.feelsweirdman>친구 근처에 있을 때, 그들은 [bleedResistance]% 출혈 저항력을 얻고 출혈 상처 지속 시간을 [bleedWound]% 줄입니다.</talentdescription.feelsweirdman>
   <talentname.bestfriends>영원한 친구</talentname.bestfriends>

--- a/Language/LatinamericanSpanish/LatinamericanSpanish.xml
+++ b/Language/LatinamericanSpanish/LatinamericanSpanish.xml
@@ -2,8 +2,8 @@
 <infotexts language="Latinamerican Spanish" nowhitespace="false" translatedname="Latinamerican Spanish">
   <jobName.PlayerHuskJob>Husk</jobName.PlayerHuskJob>
   <jobdescription.PlayerHuskJob>Un cadáver en descomposición metido en un antiguo traje de buzo, se deslizó a través de la esclusa y nunca se molestó en salir. Nadie sabe lo que quiere, si es que quiere algo en absoluto. Merodea por los corredores, a veces temblando, a veces babeando un fluido oscuro y viscoso que huele ligeramente a salmuera. Algunos dicen que hace un clic suave por la noche, un sonido hueco que sacude los mamparos. Lo que una vez fue, ahora es algo más, y ha decidido quedarse.</jobdescription.PlayerHuskJob>
-  <talentname.symbiosis>Simbiogénesis</talentname.symbiosis>
-  <talentdescription.symbiosis>Mientras estén cerca de amigos, ganan un [stun]% de resistencia al aturdimiento y resistencia al daño. Cada vez que sanas a un aliado, también te sanas a ti mismo por un [healing]% de esa cantidad.</talentdescription.symbiosis>
+  <talentname.hh_symbiosis>Simbiogénesis</talentname.hh_symbiosis>
+  <talentdescription.hh_symbiosis>Mientras estén cerca de amigos, ganan un [stun]% de resistencia al aturdimiento y resistencia al daño. Cada vez que sanas a un aliado, también te sanas a ti mismo por un [healing]% de esa cantidad.</talentdescription.hh_symbiosis>
   <talentname.feelsweirdman>Secreción maravillosa</talentname.feelsweirdman>
   <talentdescription.feelsweirdman>Mientras estén cerca de amigos, ganan un [bleedResistance]% de resistencia a las hemorragias y reducen la duración de las heridas por hemorragia en un [bleedWound]%.</talentdescription.feelsweirdman>
   <talentname.bestfriends>Mejores amigos para siempre</talentname.bestfriends>

--- a/Language/Polish/Polish.xml
+++ b/Language/Polish/Polish.xml
@@ -2,8 +2,8 @@
 <infotexts language="Polish" nowhitespace="false" translatedname="Polish">
   <jobName.PlayerHuskJob>Husk</jobName.PlayerHuskJob>
   <jobdescription.PlayerHuskJob>Zgniłe ciało wciśnięte w starożytny skafander nurkowy, dryfowało przez właz i nigdy nie miało zamiaru odejść. Nikt nie wie, czego chce - jeśli w ogóle chce czegokolwiek. Włóczy się po korytarzach, czasami drgając, czasami śliniąc się ciemną, lepką cieczą, która lekko pachnie solanką. Niektórzy twierdzą, że w nocy cicho klika, co jest pustym dźwiękiem, który wstrząsa grodzami. Czymkolwiek było, teraz jest czymś innym i postanowiło zostać.</jobdescription.PlayerHuskJob>
-  <talentname.symbiosis>Symbioza</talentname.symbiosis>
-  <talentdescription.symbiosis>Będąc blisko przyjaciół, zyskują [stun]% odporności na ogłuszenie i odporności na obrażenia. Kiedy leczysz sojusznika, również leczy się za [healing]% tej kwoty.</talentdescription.symbiosis>
+  <talentname.hh_symbiosis>Symbioza</talentname.hh_symbiosis>
+  <talentdescription.hh_symbiosis>Będąc blisko przyjaciół, zyskują [stun]% odporności na ogłuszenie i odporności na obrażenia. Kiedy leczysz sojusznika, również leczy się za [healing]% tej kwoty.</talentdescription.hh_symbiosis>
   <talentname.feelsweirdman>Wspaniała sekrecja</talentname.feelsweirdman>
   <talentdescription.feelsweirdman>Będąc blisko przyjaciół, zyskują [bleedResistance]% odporności na krwawienie i skracają czas trwania ran krwawiących o [bleedWound]%.</talentdescription.feelsweirdman>
   <talentname.bestfriends>Najlepsi przyjaciele na zawsze</talentname.bestfriends>

--- a/Language/Russian/Russian.xml
+++ b/Language/Russian/Russian.xml
@@ -2,8 +2,8 @@
 <infotexts language="Russian" nowhitespace="false" translatedname="Russian">
   <jobName.PlayerHuskJob>Husk</jobName.PlayerHuskJob>
   <jobdescription.PlayerHuskJob>Гниющее тело, запихнутое в древний костюм водолаза, оно проплыло через шлюз и никогда не уходит. Никто не знает, чего оно хочет - если вообще чего-то хочет. Оно бродит по коридорам, время от времени дергаясь, время от времени подтекая темной, вязкой жидкостью, которая слегка пахнет соленой водой. Некоторые говорят, что оно тихо щелкает ночью, пустой звук, который гремит по переборкам. Чем бы оно ни было раньше, теперь это что-то другое, и оно решило остаться.</jobdescription.PlayerHuskJob>
-  <talentname.symbiosis>Симбиоз</talentname.symbiosis>
-  <talentdescription.symbiosis>Находясь рядом с друзьями, они получают [stun]% сопротивления оглушению и сопротивления урону. Каждый раз, когда вы лечите союзника, вы также лечите себя на [healing]% от этой суммы.</talentdescription.symbiosis>
+  <talentname.hh_symbiosis>Симбиоз</talentname.hh_symbiosis>
+  <talentdescription.hh_symbiosis>Находясь рядом с друзьями, они получают [stun]% сопротивления оглушению и сопротивления урону. Каждый раз, когда вы лечите союзника, вы также лечите себя на [healing]% от этой суммы.</talentdescription.hh_symbiosis>
   <talentname.feelsweirdman>Чудесная секреция</talentname.feelsweirdman>
   <talentdescription.feelsweirdman>Находясь рядом с друзьями, они получают [bleedResistance]% сопротивления кровотечению и сокращают длительность кровоточащих ран на [bleedWound]%.</talentdescription.feelsweirdman>
   <talentname.bestfriends>Лучшие друзья навсегда</talentname.bestfriends>

--- a/Language/SimplifiedChinese/SimplifiedChinese.xml
+++ b/Language/SimplifiedChinese/SimplifiedChinese.xml
@@ -2,8 +2,8 @@
 <infotexts language="Simplified Chinese" nowhitespace="false" translatedname="Simplified Chinese">
   <jobName.PlayerHuskJob>尸体</jobName.PlayerHuskJob>
   <jobdescription.PlayerHuskJob>一个腐烂的尸体被塞进了一套古老的潜水服中，它漂浮进了气闸，却从未打算离开。没有人知道它想要什么——如果它真的想要什么的话。它徘徊在走廊里，偶尔抽搐，偶尔流出一股暗淡的粘稠液体，散发着微弱的盐水味。有些人说它在夜里轻轻发出咔嗒声，那是一种空洞的声音，让隔板震动。无论它曾经是什么，现在它已是其他东西，并决定留下来。</jobdescription.PlayerHuskJob>
-  <talentname.symbiosis>共生</talentname.symbiosis>
-  <talentdescription.symbiosis>在朋友附近时，他们获得 [stun]% 的眩晕抗性和伤害抗性。每当你治疗一个盟友时，你也会为自己治疗 [healing]% 的生命值。</talentdescription.symbiosis>
+  <talentname.hh_symbiosis>共生</talentname.hh_symbiosis>
+  <talentdescription.hh_symbiosis>在朋友附近时，他们获得 [stun]% 的眩晕抗性和伤害抗性。每当你治疗一个盟友时，你也会为自己治疗 [healing]% 的生命值。</talentdescription.hh_symbiosis>
   <talentname.feelsweirdman>奇妙分泌物</talentname.feelsweirdman>
   <talentdescription.feelsweirdman>在朋友附近时，他们获得 [bleedResistance]% 的流血抗性，并将流血伤害的持续时间减少 [bleedWound]%。</talentdescription.feelsweirdman>
   <talentname.bestfriends>永远的好朋友</talentname.bestfriends>

--- a/Language/TraditionalChinese/TraditionalChinese.xml
+++ b/Language/TraditionalChinese/TraditionalChinese.xml
@@ -2,8 +2,8 @@
 <infotexts language="Traditional Chinese" nowhitespace="false" translatedname="Traditional Chinese">
   <jobName.PlayerHuskJob>殭屍</jobName.PlayerHuskJob>
   <jobdescription.PlayerHuskJob>一具腐爛的屍體被塞進一套古老的潛水服，它漂浮進入了氣閘，卻從未打算離開。沒有人知道它想要什麼——即使它真的想要什麼。它徘徊在走廊上，偶爾抽搐，偶爾流出一種淡淡的鹽水氣味的深色粘稠液體。有人說它在夜裡輕聲咔嗒作響，那是一種空洞的聲音，讓艙壁顫動。無論它曾經是什麼，現在它已經變得不一樣，而它決定留下來。</jobdescription.PlayerHuskJob>
-  <talentname.symbiosis>共生</talentname.symbiosis>
-  <talentdescription.symbiosis>當靠近朋友時，他們獲得 [stun]% 的眩暈抵抗和傷害抵抗。每當你治療一名盟友時，你也會為自己治療該數量的 [healing]%。</talentdescription.symbiosis>
+  <talentname.hh_symbiosis>共生</talentname.hh_symbiosis>
+  <talentdescription.hh_symbiosis>當靠近朋友時，他們獲得 [stun]% 的眩暈抵抗和傷害抵抗。每當你治療一名盟友時，你也會為自己治療該數量的 [healing]%。</talentdescription.hh_symbiosis>
   <talentname.feelsweirdman>奇怪的分泌物</talentname.feelsweirdman>
   <talentdescription.feelsweirdman>當靠近朋友時，他們獲得 [bleedResistance]% 的流血抵抗並減少流血傷口的持續時間 [bleedWound]%。</talentdescription.feelsweirdman>
   <talentname.bestfriends>永遠的好朋友</talentname.bestfriends>

--- a/Language/Ukrainian.xml
+++ b/Language/Ukrainian.xml
@@ -2,8 +2,8 @@
 <infotexts language="Ukrainian" nowhitespace="false" translatedname="Ukrainian">
   <jobName.PlayerHuskJob>Гуск</jobName.PlayerHuskJob>
   <jobdescription.PlayerHuskJob>Гниле тіло, набите в старий костюм дайвера, занесло в шлюз і воно так і не пішло. Ніхто не знає, чого воно хоче — якщо взагалі хоче чогось. Воно блукає коридорами, час від часу тремтить, час від часу пускає темну, в'язку рідину, що злегка пахне сольовим розчином. Дехто каже, що вночі воно тихо клацає, видаючи порожній звук, що грюкає по перебіркам. Чим би воно не було колись, тепер це щось інше, і воно вирішило залишитися.</jobdescription.PlayerHuskJob>
-  <talentname.symbiosis>Симбіоз</talentname.symbiosis>
-  <talentdescription.symbiosis>Поряд з друзями, вони отримують [stun]% стійкості до оглушення та стійкості до урону. Коли ви лікуєте союзника, ви також лікуєте себе на [healing]% від цієї кількості.</talentdescription.symbiosis>
+  <talentname.hh_symbiosis>Симбіоз</talentname.hh_symbiosis>
+  <talentdescription.hh_symbiosis>Поряд з друзями, вони отримують [stun]% стійкості до оглушення та стійкості до урону. Коли ви лікуєте союзника, ви також лікуєте себе на [healing]% від цієї кількості.</talentdescription.hh_symbiosis>
   <talentname.feelsweirdman>Чудодійна секреція</talentname.feelsweirdman>
   <talentdescription.feelsweirdman>Поряд з друзями, вони отримують [bleedResistance]% стійкості до кровотечі та зменшують тривалість кровотечі на [bleedWound]%.</talentdescription.feelsweirdman>
   <talentname.bestfriends>Найкращі друзі назавжди</talentname.bestfriends>

--- a/Lua/Scripts/init.lua
+++ b/Lua/Scripts/init.lua
@@ -83,7 +83,7 @@ local function OnApplyMedicationFromHusk(item, usingCharacter, targetCharacter, 
         return false
     end
 
-    if not usingCharacter.HasTalent("symbiosis") then
+    if not usingCharacter.HasTalent("hh_symbiosis") then
         return false
     end
 

--- a/filelist.xml
+++ b/filelist.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<contentpackage name="Hunter's Husk Job" modversion="1.0.48" corepackage="False" steamworkshopid="3384404945" gameversion="1.8.8.1">
+<contentpackage name="Hunter's Husk Job" modversion="1.0.49" corepackage="False" steamworkshopid="3384404945" gameversion="1.8.8.1">
   <Jobs file="%ModDir%/Job/Jobs.xml" />
   <TalentTrees file="%ModDir%/Job/TalentTrees.xml" />
   <Afflictions file="%ModDir%/Job/TalentAfflictions.xml" />


### PR DESCRIPTION
Many other mods have the "symbiosis" talent, prefixing it should fix the duplication issue when people are trying to add multiple mods with the same talent.